### PR TITLE
Implemented reflection to find all node types

### DIFF
--- a/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/GeneratorNodes/PerlinNode.cs
+++ b/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/GeneratorNodes/PerlinNode.cs
@@ -11,10 +11,9 @@ public class PerlinNode : Node
 {
     private Perlin _noise = new Perlin();
 
-    public PerlinNode()
-    {
-        name = "Perlin";
+    public override string name { get { return "Perlin Noise"; } }
 
+    public override void Init() {
         var noiseIn = AddInput();
         noiseIn.name = "Input";
 

--- a/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/GeneratorNodes/PerlinNode.cs
+++ b/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/GeneratorNodes/PerlinNode.cs
@@ -13,7 +13,7 @@ public class PerlinNode : Node
 
     public override string name { get { return "Perlin Noise"; } }
 
-    public override void Init() {
+    public override void Init() { 
         var noiseIn = AddInput();
         noiseIn.name = "Input";
 

--- a/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/GeneratorNodes/VoronoiNode.cs
+++ b/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/GeneratorNodes/VoronoiNode.cs
@@ -5,12 +5,12 @@ using UNEB;
 
 public class VoronoiNode : Node
 {
+    public override string name { get { return "Voronoi"; } }
+
     private Voronoi _noise = new Voronoi();
 
-    public VoronoiNode()
+    public override void Init()
     {
-        name = "Voronoi";
-
         var noiseIn = AddInput();
         noiseIn.name = "Input";
 

--- a/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/OperatorNodes/CurveNode.cs
+++ b/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/OperatorNodes/CurveNode.cs
@@ -5,16 +5,15 @@ using UNEB;
 
 public class CurveNode : Node
 {
+    public override string name { get { return "Curve"; } }
 
     private AnimationCurve _curve = new AnimationCurve();
     private readonly Rect kCurveRange = new Rect(-1, -1, 2, 2);
 
     private const float kBodyHeight = 100f;
 
-    public CurveNode()
+    public override void Init()
     {
-        name = "Curve";
-
         var input = AddInput();
         input.name = "Input";
 

--- a/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/OperatorNodes/SelectNode.cs
+++ b/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/OperatorNodes/SelectNode.cs
@@ -6,12 +6,12 @@ using UNEB;
 
 public class SelectNode : Node
 {
+    public override string name { get { return "Select"; } }
+
     private Select _op = new Select();
 
-    public SelectNode()
+    public override void Init()
     {
-        name = "Select";
-
         var inputA = AddInput();
         inputA.name = "Input A";
 

--- a/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/OutputMesh.cs
+++ b/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/OutputMesh.cs
@@ -3,6 +3,6 @@ using UnityEngine;
 using UNEB;
 
 public class OutputMesh : Node {
+    public override string name { get { return "Perlin Noise"; } }
 
-	
 }

--- a/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/OutputTexture2D.cs
+++ b/UNEB_Project_Root/Assets/Examples/LibNoiseEditor/Nodes/OutputTexture2D.cs
@@ -5,6 +5,7 @@ using UNEB;
 
 public class OutputTexture2D : Node
 {
+    public override string name { get { return "Output Texture2D"; } }
 
     private Texture2D texPreview;
 
@@ -17,7 +18,7 @@ public class OutputTexture2D : Node
         set { _texRes = Mathf.Clamp(value, 10, 300); }
     }
 
-    public OutputTexture2D()
+    public override void Init()
     {
         inputNoise = AddInput();
         inputNoise.name = "Input Noise";

--- a/UNEB_Project_Root/Assets/UNEB/Node.cs
+++ b/UNEB_Project_Root/Assets/UNEB/Node.cs
@@ -9,8 +9,13 @@ namespace UNEB
     /// <summary>
     /// The visual representation of a logic unit such as an object or function.
     /// </summary>
-    public class Node : ScriptableObject
+    public abstract class Node : ScriptableObject
     {
+        /// <summary>
+        /// The name of the node.
+        /// </summary>
+        public abstract new string name { get; }
+
         public static readonly Vector2 kDefaultSize = new Vector2(140f, 110f);
 
         /// <summary>
@@ -73,9 +78,7 @@ namespace UNEB
         /// <summary>
         /// Use this for initialization.
         /// </summary>
-        public virtual void Init()
-        {
-            name = "Node";
+        public virtual void Init() {
             bodyRect.size = kDefaultSize;
         }
 

--- a/UNEB_Project_Root/Assets/UNEB/Nodes/BasicNode.cs
+++ b/UNEB_Project_Root/Assets/UNEB/Nodes/BasicNode.cs
@@ -6,13 +6,13 @@ namespace UNEB
 {
     public class BasicNode : Node
     {
+        public override string name { get { return "Basic Node"; } }
+
         private int _someInt = 0;
 
         public override void Init()
         {
             base.Init();
-
-            name = "Basic Node";
 
             AddInput("Input");
             AddOutput("Ouput");


### PR DESCRIPTION
Changes:
 - Node.cs made abstract and 'name' made an abstract. This will make it easier to get the name without initializing the node. It will also fail to compile if the user hasn't given a name to a custom node. Should we make **Init()** abstract as well? I can't imagine a situation where you wouldn't want an **Init()**.
 - Custom node constructors replaced with void Init()

Boy, did I spend a lot of time trying to keep my feature branch and master branch separate while updating the master branch. 